### PR TITLE
Refactor/reissue

### DIFF
--- a/src/main/java/com/example/hotsix/controller/auth/ReissueController.java
+++ b/src/main/java/com/example/hotsix/controller/auth/ReissueController.java
@@ -3,17 +3,14 @@ package com.example.hotsix.controller.auth;
 
 
 import com.example.hotsix.dto.auth.ReissueResponse;
-import com.example.hotsix.dto.member.MemberDto;
 import com.example.hotsix.enums.Process;
 import com.example.hotsix.exception.BuiltInException;
-import com.example.hotsix.jwt.JWTUtil;
-import com.example.hotsix.service.auth.RedisTokenService;
+import com.example.hotsix.service.auth.ReissueService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,57 +21,18 @@ import java.util.Optional;
 @Slf4j
 public class ReissueController {
 
-
-    private final JWTUtil jwtUtil;
-    private final RedisTokenService redisTokenService;
-
-    @Value("${jwt.access-token.expiretime}")
-    private Long accessExpiretime;
+    private final ReissueService reissueService;
 
     @PostMapping("/reissue")
     public ReissueResponse reissue(HttpServletRequest request, HttpServletResponse response) {
         log.info("reissue");
         String refresh = getToeknFromCookie(request).orElseThrow(() -> new BuiltInException(Process.INVALID_TOKEN));
-        validateRefreshToken(refresh);
+        String newAccess = reissueService.reissueAcessToken(refresh);
 
-        String newAccess = reissueAcessToken(refresh);
         response.setHeader("Authorization", "Bearer " + newAccess);
-
         return ReissueResponse.builder()
                 .token(newAccess)
                 .build();
-    }
-
-    private String reissueAcessToken(String refresh) {
-        String role = jwtUtil.getRole(refresh);
-        Long id= jwtUtil.getId(refresh);
-        String name = jwtUtil.getName(refresh);
-        String email = jwtUtil.getEmail(refresh);
-
-        MemberDto memberDto = MemberDto.builder()
-                .id(id)
-                .email(email)
-                .name(name)
-                .role(role)
-                .build();
-
-        return jwtUtil.createAccessToken(memberDto, accessExpiretime);
-    }
-
-    private void validateRefreshToken(String refresh) {
-        try {
-            jwtUtil.validateToken(refresh);
-            jwtUtil.isTokenTypeRefresh(refresh);
-            isAleadyLogoutToken(refresh);
-        }catch (BuiltInException e){
-            throw e;
-        }
-    }
-
-    private void isAleadyLogoutToken(String refresh) {
-        if(!redisTokenService.isTokenInRedis(jwtUtil.getId(refresh).toString()))
-            throw new BuiltInException(Process.INVALID_TOKEN);
-
     }
 
     private static Optional<String> getToeknFromCookie(HttpServletRequest request) {

--- a/src/main/java/com/example/hotsix/service/auth/ReissueService.java
+++ b/src/main/java/com/example/hotsix/service/auth/ReissueService.java
@@ -1,4 +1,51 @@
 package com.example.hotsix.service.auth;
 
+import com.example.hotsix.dto.member.MemberDto;
+import com.example.hotsix.enums.Process;
+import com.example.hotsix.exception.BuiltInException;
+import com.example.hotsix.jwt.JWTUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class ReissueService {
+    private final JWTUtil jwtUtil;
+    private final RedisTokenService redisTokenService;
+    @Value("${jwt.access-token.expiretime}")
+    private Long accessExpiretime;
+
+    public String reissueAcessToken(String refresh) {
+        validateRefreshToken(refresh);
+
+        String role = jwtUtil.getRole(refresh);
+        Long id= jwtUtil.getId(refresh);
+        String name = jwtUtil.getName(refresh);
+        String email = jwtUtil.getEmail(refresh);
+        MemberDto memberDto = MemberDto.builder()
+                .id(id)
+                .email(email)
+                .name(name)
+                .role(role)
+                .build();
+
+        return jwtUtil.createAccessToken(memberDto, accessExpiretime);
+    }
+
+    private void validateRefreshToken(String refresh) {
+        try {
+            jwtUtil.validateToken(refresh);
+            jwtUtil.isTokenTypeRefresh(refresh);
+            isAleadyLogoutToken(refresh);
+        }catch (BuiltInException e){
+            throw e;
+        }
+    }
+
+    private void isAleadyLogoutToken(String refresh) {
+        if(!redisTokenService.isTokenInRedis(jwtUtil.getId(refresh).toString()))
+            throw new BuiltInException(Process.INVALID_TOKEN);
+    }
+
 }

--- a/src/main/java/com/example/hotsix/service/auth/ReissueService.java
+++ b/src/main/java/com/example/hotsix/service/auth/ReissueService.java
@@ -1,0 +1,4 @@
+package com.example.hotsix.service.auth;
+
+public class ReissueService {
+}

--- a/src/main/java/com/example/hotsix/service/auth/ReissueService.java
+++ b/src/main/java/com/example/hotsix/service/auth/ReissueService.java
@@ -37,13 +37,13 @@ public class ReissueService {
         try {
             jwtUtil.validateToken(refresh);
             jwtUtil.isTokenTypeRefresh(refresh);
-            isAleadyLogoutToken(refresh);
+            isLoggedOutToken(refresh);
         }catch (BuiltInException e){
             throw e;
         }
     }
 
-    private void isAleadyLogoutToken(String refresh) {
+    private void isLoggedOutToken(String refresh) {
         if(!redisTokenService.isTokenInRedis(jwtUtil.getId(refresh).toString()))
             throw new BuiltInException(Process.INVALID_TOKEN);
     }

--- a/src/test/java/com/example/hotsix/jwt/ReissueControllerTest.java
+++ b/src/test/java/com/example/hotsix/jwt/ReissueControllerTest.java
@@ -2,7 +2,10 @@ package com.example.hotsix.jwt;
 
 import com.example.hotsix.controller.auth.ReissueController;
 import com.example.hotsix.dto.member.MemberDto;
+import com.example.hotsix.enums.Process;
+import com.example.hotsix.exception.BuiltInException;
 import com.example.hotsix.service.auth.RedisTokenService;
+import com.example.hotsix.service.auth.ReissueService;
 import com.example.hotsix.service.storage.StorageService;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
@@ -30,9 +33,7 @@ public class ReissueControllerTest {
     @Autowired
     private MockMvc mockMvc;
     @MockBean
-    private JWTUtil jwtUtil;
-    @MockBean
-    private RedisTokenService redisTokenService;
+    private ReissueService reissueService;
     @MockBean
     private StorageService storageService;
     @MockBean
@@ -42,26 +43,11 @@ public class ReissueControllerTest {
     @Test
     @DisplayName("AccessToken 재발행 테스트")
     void reissueAccessToken() throws Exception {
-
-        Long expectedUserId = 1L;
-        String expectedUsername = "testUser";
-        String expectedRole = "ROLE_USER";
-        String expectedName = "Test User Name";
-        String expectedEmail = "test@example.com";
         String refreshToken = "refreshToken";
         String newAccessToken = "newAccessToken";
         Cookie refresh = new Cookie("refresh", refreshToken);
 
-        Mockito.when(jwtUtil.getCategory(refreshToken)).thenReturn("refresh");
-        Mockito.when(jwtUtil.getId(refreshToken)).thenReturn(expectedUserId);
-        Mockito.when(jwtUtil.getUsername(refreshToken)).thenReturn(expectedUsername);
-        Mockito.when(jwtUtil.getRole(refreshToken)).thenReturn(expectedRole);
-        Mockito.when(jwtUtil.getName(refreshToken)).thenReturn(expectedName);
-        Mockito.when(jwtUtil.getEmail(refreshToken)).thenReturn(expectedEmail);
-        Mockito.when(redisTokenService.isTokenInRedis("1")).thenReturn(true);
-        Mockito.when(jwtUtil.createAccessToken(any(MemberDto.class), anyLong()))
-                .thenReturn(newAccessToken);
-
+        Mockito.when(reissueService.reissueAcessToken(refreshToken)).thenReturn(newAccessToken);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/reissue")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -73,7 +59,6 @@ public class ReissueControllerTest {
                 .andExpect(jsonPath("$.process.message").value("정상적인 응답을 반환하였습니다"))
                 .andExpect(jsonPath("$.data").exists())
                 .andExpect(jsonPath("$.data.token").exists());
-
     }
 
     @Test
@@ -81,45 +66,7 @@ public class ReissueControllerTest {
     void expiredRefreshToken() throws Exception {
         String refreshToken = "refreshToken";
         Cookie refresh = new Cookie("refresh", refreshToken);
-
-        Mockito.when(jwtUtil.validateToken(refreshToken)).thenReturn(false);
-        Mockito.when(jwtUtil.getCategory(refreshToken)).thenReturn("refresh");
-
-
-        mockMvc.perform(MockMvcRequestBuilders.post("/reissue")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(refresh)
-                        .with(csrf()))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.process").exists())
-                .andExpect(jsonPath("$.process.statusCode").value(401))
-                .andExpect(jsonPath("$.process.message").value("잘못된 JWT Token 입니다."))
-                .andExpect(jsonPath("$.data").doesNotExist());
-
-    }
-
-    @Test
-    @DisplayName("이미 로그아웃된 refreshToken 테스트")
-    void aleadyLogoutRefreshToken() throws Exception {
-        Long expectedUserId = 1L;
-        String expectedUsername = "testUser";
-        String expectedRole = "ROLE_USER";
-        String expectedName = "Test User Name";
-        String expectedEmail = "test@example.com";
-        String refreshToken = "refreshToken";
-        String newAccessToken = "newAccessToken";
-        Cookie refresh = new Cookie("refresh", refreshToken);
-
-        Mockito.when(jwtUtil.getCategory(refreshToken)).thenReturn("refresh");
-        Mockito.when(jwtUtil.getId(refreshToken)).thenReturn(expectedUserId);
-        Mockito.when(jwtUtil.getUsername(refreshToken)).thenReturn(expectedUsername);
-        Mockito.when(jwtUtil.getRole(refreshToken)).thenReturn(expectedRole);
-        Mockito.when(jwtUtil.getName(refreshToken)).thenReturn(expectedName);
-        Mockito.when(jwtUtil.getEmail(refreshToken)).thenReturn(expectedEmail);
-        Mockito.when(redisTokenService.isTokenInRedis("1")).thenReturn(false);
-        Mockito.when(jwtUtil.createAccessToken(any(MemberDto.class), anyLong()))
-                .thenReturn(newAccessToken);
-
+        Mockito.when(reissueService.reissueAcessToken(refreshToken)).thenThrow(new BuiltInException(Process.INVALID_TOKEN));
 
         mockMvc.perform(MockMvcRequestBuilders.post("/reissue")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/example/hotsix/jwt/ReissueServiceTest.java
+++ b/src/test/java/com/example/hotsix/jwt/ReissueServiceTest.java
@@ -1,0 +1,82 @@
+
+package com.example.hotsix.jwt;
+
+import com.example.hotsix.dto.member.MemberDto;
+import com.example.hotsix.enums.Process;
+import com.example.hotsix.exception.BuiltInException;
+import com.example.hotsix.service.auth.RedisTokenService;
+import com.example.hotsix.service.auth.ReissueService;
+import com.example.hotsix.service.storage.StorageService;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+
+@Import(SecurityConfiguration.class)
+@ExtendWith(MockitoExtension.class)
+public class ReissueServiceTest {
+
+    @InjectMocks
+    private ReissueService reissueService;
+    @Mock
+    private JWTUtil jwtUtil;
+    @Mock
+    private RedisTokenService redisTokenService;
+    @MockBean
+    private StorageService storageService;
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @BeforeEach
+    void setReissueService(){
+        ReflectionTestUtils.setField(reissueService, "accessExpiretime", 100000L);
+    }
+
+
+    @Test
+    @DisplayName("AccessToken 재발행 테스트")
+    void reissueAccessToken() throws Exception {
+
+        Long expectedUserId = 1L;
+        String expectedRole = "ROLE_USER";
+        String expectedName = "Test User Name";
+        String expectedEmail = "test@example.com";
+        String refreshToken = "refreshToken";
+        String expectedAccessToken = "newAccessToken";
+
+        Mockito.when(jwtUtil.validateToken(refreshToken)).thenReturn(true);
+        Mockito.when(jwtUtil.isTokenTypeRefresh(refreshToken)).thenReturn(true);
+        Mockito.when(jwtUtil.getId(refreshToken)).thenReturn(expectedUserId);
+        Mockito.when(redisTokenService.isTokenInRedis("1")).thenReturn(true);
+        Mockito.when(jwtUtil.getRole(refreshToken)).thenReturn(expectedRole);
+        Mockito.when(jwtUtil.getEmail(refreshToken)).thenReturn(expectedEmail);
+        Mockito.when(jwtUtil.getName(refreshToken)).thenReturn(expectedName);
+        Mockito.when(jwtUtil.createAccessToken(any(MemberDto.class), anyLong())).thenReturn(expectedAccessToken);
+
+        String newAccessToken = reissueService.reissueAcessToken(refreshToken);
+        Assertions.assertEquals(expectedAccessToken, newAccessToken);
+    }
+
+    @Test
+    @DisplayName("잘못된 refresh토큰요청 테스트")
+    void expiredRefreshToken() throws Exception {
+        String refreshToken = "refreshToken";
+        Mockito.when(jwtUtil.validateToken(refreshToken)).thenThrow(new BuiltInException(Process.INVALID_TOKEN));
+
+        Assertions.assertThrows(BuiltInException.class, () -> reissueService.reissueAcessToken(refreshToken));
+    }
+
+}


### PR DESCRIPTION
accesstoken 재발행 service 분리 리팩토링

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **리팩터**
  - 토큰 재발행 컨트롤러가 내부 검증 및 토큰 생성 로직을 서비스로 위임하도록 구조를 개선하였습니다.

- **신규 기능**
  - 토큰 재발행을 담당하는 서비스가 추가되었습니다.

- **테스트**
  - 컨트롤러 테스트가 서비스 단위로 단순화되었으며, 토큰 재발행 서비스에 대한 단위 테스트가 새로 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->